### PR TITLE
Added workflow dependency to dependabot

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,18 +1,17 @@
 name: "Dependabot Automerge"
+
 on:
-  pull_request:
   workflow_run:
-    workflows: ["Java CI with Maven", "CodeQL"]
+    workflows: ["Pull request"]
     types:
       - completed
 
-  
 permissions:
   pull-requests: write
   contents: write
-  
+
 jobs:
-  worker:
+  automerge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,11 @@
 name: "Dependabot Automerge"
 on:
-  pull_request
+  pull_request:
+  workflow_run:
+    workflows: ["Java CI with Maven", "CodeQL"]
+    types:
+      - completed
+
   
 permissions:
   pull-requests: write

--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
     
 jobs:
-  get_data:
+  diagrams:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,14 +6,11 @@ name: Java CI with Maven
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_call:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,9 @@
+name: "Pull request"
+
+on:
+  pull_request
+
+jobs:
+  build:
+    uses: jensborch/webhooks4j/.github/workflows/maven.yml@main
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ target
 *.iml
 .factorypath
 socomo.html
+pom.xml.versionsBackup
+nb-configuration.xml


### PR DESCRIPTION
I have used reusable workflows (https://docs.github.com/en/actions/using-workflows/reusing-workflows) to ensure that a successful build is done before merging a Dependabot PR. I am not 100% sure this is the best solution, so any suggestions are welcome ;-)